### PR TITLE
Kamailio regex for callid within rtcp-xr publish

### DIFF
--- a/sipcapture/sipcapture.kamailio
+++ b/sipcapture/sipcapture.kamailio
@@ -268,7 +268,7 @@ route {
                 if($cT == "application/vq-rtcpxr" && $(rb{s.substr,0,1}) != "x") {
                         $var(table) = "report_capture";
                         #$var(callid) = $(rb{re.subst,/(.*)CallID:([0-9A-Za-z_.@-]{5,120})(.*)$/\2/s});
-                        $var(callid) = $(rb{re.subst,/.*CallID:([0-9A-Za-z@-_\.]{5,120}).*$/\1/s});
+                        $var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
 
 			#Local IP. Only for stats
 			#$var(localaddress) = $(rb{re.subst,/.*LocalAddr:IP=([^\S]+).*$/\1/s});

--- a/sipcapture/sipcapture.kamailio
+++ b/sipcapture/sipcapture.kamailio
@@ -268,7 +268,7 @@ route {
                 if($cT == "application/vq-rtcpxr" && $(rb{s.substr,0,1}) != "x") {
                         $var(table) = "report_capture";
                         #$var(callid) = $(rb{re.subst,/(.*)CallID:([0-9A-Za-z_.@-]{5,120})(.*)$/\2/s});
-                        $var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
+                        $var(callid) = $(rb{re.subst,/.*CallID:\s*([0-9A-Za-z@_\.\-]{5,120}).*$/\1/s});
 
 			#Local IP. Only for stats
 			#$var(localaddress) = $(rb{re.subst,/.*LocalAddr:IP=([^\S]+).*$/\1/s});

--- a/sipcapture/sipcapture.kamailio4.elastic
+++ b/sipcapture/sipcapture.kamailio4.elastic
@@ -317,7 +317,7 @@ route {
 		if($cT == "application/vq-rtcpxr" && $(rb{s.substr,0,1}) != "x") {
 			$var(table) = "report_capture";
 			#$var(callid) = $(rb{re.subst,/(.*)CallID:([0-9A-Za-z_.@-]{5,120})(.*)$/\2/s});
-			$var(callid) = $(rb{re.subst,/.*CallID:([0-9A-Za-z@-_\.]{5,120}).*$/\1/s});
+			$var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
 
 			#Local IP. Only for stats
 			#$var(localaddress) = $(rb{re.subst,/.*LocalAddr:IP=([^\S]+).*$/\1/s});

--- a/sipcapture/sipcapture.kamailio4.elastic
+++ b/sipcapture/sipcapture.kamailio4.elastic
@@ -317,7 +317,7 @@ route {
 		if($cT == "application/vq-rtcpxr" && $(rb{s.substr,0,1}) != "x") {
 			$var(table) = "report_capture";
 			#$var(callid) = $(rb{re.subst,/(.*)CallID:([0-9A-Za-z_.@-]{5,120})(.*)$/\2/s});
-			$var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
+			$var(callid) = $(rb{re.subst,/.*CallID:\s*([0-9A-Za-z@_\.\-]{5,120}).*$/\1/s});
 
 			#Local IP. Only for stats
 			#$var(localaddress) = $(rb{re.subst,/.*LocalAddr:IP=([^\S]+).*$/\1/s});

--- a/sipcapture/sipcapture.kamailio5
+++ b/sipcapture/sipcapture.kamailio5
@@ -283,7 +283,7 @@ route {
         {
                 if(has_body("application/vq-rtcpxr") && $(rb{s.substr,0,1}) != "x") {
                         $var(table) = "report_capture";
-                        $var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
+                        $var(callid) = $(rb{re.subst,/.*CallID:\s*([0-9A-Za-z@_\.\-]{5,120}).*$/\1/s});
                         #xlog("CALLID: $var(callid)");
 #!ifdef KAMAILIO_4_3
 			xlog("report_capture is not in < 4.3");

--- a/sipcapture/sipcapture.kamailio5
+++ b/sipcapture/sipcapture.kamailio5
@@ -283,7 +283,7 @@ route {
         {
                 if(has_body("application/vq-rtcpxr") && $(rb{s.substr,0,1}) != "x") {
                         $var(table) = "report_capture";
-                        $var(callid) = $(rb{re.subst,/(.*)CallID:([0-9A-Za-z@-]{5,120})(.*)$/\2/s});
+                        $var(callid) = $(rb{re.subst,/.*CallID:\s*(([0-9A-Za-z@_\.\-]{5,120})).*$/\1/s});
                         #xlog("CALLID: $var(callid)");
 #!ifdef KAMAILIO_4_3
 			xlog("report_capture is not in < 4.3");


### PR DESCRIPTION
The "-" character needs to be escaped in the character class block (between the square brackets), it also, incidentally, needs to be placed at the end of the character class block.

I added the option of zero or more spaces between the "CallID:" and its value, as the Pollycom phones don't have spaces between the "header" and "value" fields, where the Panasonic phones do have a space.

Attempts to address sipcapture/homer issue #231