### PR TITLE
Update sipcapture.kamailio5 : escape json content of RTCP reports

### DIFF
--- a/sipcapture/sipcapture.kamailio5
+++ b/sipcapture/sipcapture.kamailio5
@@ -968,7 +968,8 @@ event_route[sipcapture:request] {
 		$var(millisec) = "("+$var(timesec)+"*10000000+"+$var(timeusec)+")";
 
                 #xlog("HEP RTCP JSON PAYLOAD [$var(json)]. Id: $var(correlation_id)\r\n");
-                sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$var(json)')");
+                #sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$var(json)')");
+		sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$(var(json){s.escape.common})')");
                 return 0;
         }
 	 #####################XLOG###############################
@@ -1003,7 +1004,8 @@ event_route[sipcapture:request] {
 		
 
                 #xlog("HEP XLOG JSON PAYLOAD [$var(json)]. Id: $var(correlation_id)\r\n");
-                sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$var(json)')");
+                #sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$var(json)')");
+		sql_query("wc", "INSERT INTO $var(table) (date, micro_ts, correlation_id, source_ip, source_port, destination_ip, destination_port, proto, family, type, node, msg) VALUES($var(t_date), $var(millisec), '$var(correlation_id)','$var(srcip)',$var(srcport),'$var(dstip)',$var(dstport),$var(proto),$var(family),$var(type),'$var(node)','$(var(json){s.escape.common})')");
                 return 0;
         }
         else 


### PR DESCRIPTION
Some your UAC sends some utf8 or non ascii in RTCP "text" field, that can't be inserted in DB if not escaped (sql query fails)
related to https://github.com/sipcapture/homer/issues/252#issuecomment-335795759