### PR TITLE
A route must not be empty.

### DIFF
--- a/metric/kamailio5/http.cfg
+++ b/metric/kamailio5/http.cfg
@@ -67,6 +67,7 @@ route[HTTP_POST] {
 		#!endif
 	}
 	#!endif
+	return;
 }
 
 #!ifdef DO_ASYNC


### PR DESCRIPTION
If neither elasticsearch, greylog or influxdb is in use, the route
won't have any statements and Kamailio refuses to start.